### PR TITLE
Fixing issue "Pressing Enter makes you lose lives"

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,11 +15,14 @@ export default function App() {
   const [gameOver, setGameOver] = useState<boolean>(false);
   const [number, setNumber] = useState<number>(151);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<boolean>(false);
+
 
   async function getPokemon() {
     setWrong(false);
     setCorrect(false);
     setIsLoading(true);
+    setError(false);
     const res = await axios.get(
       "https://pokeapi.co/api/v2/pokemon/" + Math.floor(Math.random() * number)
     );
@@ -53,6 +56,10 @@ export default function App() {
 
 
   const handlesubmit = () => {
+    if (guess === "") {
+      setError(true);
+      return;
+    }
     if (guess.toLowerCase() === pokemon?.name) {
       setSprites([
         pokemon?.sprites.versions["generation-v"]["black-white"].animated
@@ -71,11 +78,16 @@ export default function App() {
       setWrong(true);
       setVisible(true);
     }
+    setError(false);
+
   };
 
   useEffect(() => {
     const handleKeyDown = (e: { key: string; }) => {
       if (e.key === "Enter") {
+        if (correct || wrong) {
+          getPokemon();
+        }
         handlesubmit();
       }
     };
@@ -175,6 +187,13 @@ export default function App() {
         > Go </button>
       </div>
       }
+      {error ? (
+        <div className="flex flex-col items-center justify-center">
+          <h1 className="text-1xl text-red font-bold">
+            You need to enter a valid guess
+          </h1>
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Currently, after a player guesses a Pokémon and receives feedback, pressing "Enter" again results in additional lives being deducted, which is not the expected behavior. This pull request fixes this problem, ensuring that the game functions correctly after the player guesses correctly or incorrectly.

## Proposed Changes

- Added validation to prevent additional lives from being deducted when pressing "Enter" after a correct or incorrect guess.
- Implemented logic to ensure the game progresses to the next stage after the player guesses correctly or incorrectly, instead of continuing to deduct lives.

## Tests Performed

- Simulated multiple attempts to guess different Pokémon.
- Checked the behavior when pressing "Enter" after a correct or incorrect guess.
- Verified that the game correctly advances to the next stage without additional lives being deducted.


## Related Issue

Fixes #1 